### PR TITLE
1. 단축 url 뒤에 포트 번호 쓰는 경우도 탐지하도록 보완

### DIFF
--- a/src/main/java/com/veriq/veriqbe3/service/SchemeClassifier.java
+++ b/src/main/java/com/veriq/veriqbe3/service/SchemeClassifier.java
@@ -16,12 +16,17 @@ public class SchemeClassifier {
             Pattern.CASE_INSENSITIVE
     );
 
-    // 단축 URL 확인을 위한 패턴 (정확히 호스트명에 해당하는지 검사하기 위함)
     private static final List<Pattern> SHORTENER_PATTERNS = List.of(
-            Pattern.compile("^(https?://)?(www\\.)?bit\\.ly(/.*)?$", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^(https?://)?(www\\.)?t\\.co(/.*)?$", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^(https?://)?(www\\.)?goo\\.gl(/.*)?$", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^(https?://)?(www\\.)?tinyurl\\.com(/.*)?$", Pattern.CASE_INSENSITIVE)
+            Pattern.compile("^(https?://)?(www\\.)?bit\\.ly(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?t\\.co(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?goo\\.gl(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?tinyurl\\.com(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?is\\.gd(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?ow\\.ly(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?c11\\.kr(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?vvd\\.bz(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?url\\.kr(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("^(https?://)?(www\\.)?vo\\.la(:\\d+)?([/?#].*)?$", Pattern.CASE_INSENSITIVE)
     );
 
     // 2. 2차 인증 (OTP)


### PR DESCRIPTION
## 📌 작업 개요
- feat/KD-83

## 🚀 작업 내용
- 단축 url 미탐지 위험 보완

## 📸 스크린샷 (선택)
- UI 변경이 있다면 캡쳐 이미지를 첨부해주세요.

## ✅ 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 log를 제거했나요?
- [x] 테스트를 통과했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 더 많은 단축 URL 서비스(c11.kr, vvd.bz, url.kr, vo.la 등)가 이제 정확히 인식됩니다.
  * URL 패턴 인식이 개선되어 포트 및 경로 형식을 더 정확하게 처리합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Veri-Q-Project/main-server/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->